### PR TITLE
Disable drag to rotate interaction

### DIFF
--- a/build.js
+++ b/build.js
@@ -9,7 +9,8 @@ var map = new mapboxgl.Map({
   center: [-122.4387, 37.7993],
   zoom: 14,
   hash: true,
-  keyboard: false
+  keyboard: false,
+  dragRotate: false
 });
 
 map.addControl(new mapboxgl.NavigationControl({

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var map = new mapboxgl.Map({
   center: [-122.4387, 37.7993],
   zoom: 14,
   hash: true,
-  keyboard: false
+  keyboard: false,
+  dragRotate: false
 });
 
 map.addControl(new mapboxgl.NavigationControl({


### PR DESCRIPTION
Throws users off if the pitch changes by accident. See [discussion](https://github.com/mapbox/mapping/issues/255#issuecomment-270430077).